### PR TITLE
Align the balances in the budget bubbles

### DIFF
--- a/refried/extensions/accts_ext/templates/AcctsExt.html
+++ b/refried/extensions/accts_ext/templates/AcctsExt.html
@@ -18,6 +18,7 @@
 
 .tree-table .available.negative {
   padding-left: 0.7em;
+  padding-right: 0.7em;
   padding-top: 2px;
   padding-bottom: 2px;
   background-color: var(--color-budget-negative);
@@ -27,6 +28,7 @@
 
 .tree-table .available.positive {
   padding-left: 0.7em;
+  padding-right: 0.7em;
   padding-top: 2px;
   padding-bottom: 2px;
   background-color: var(--color-budget-positive);


### PR DESCRIPTION
Without this change, in Firefox the balances were right-aligned (well,
zero-padded) without respect to the border radius. This makes the
numbers centered.