### PR TITLE
Use url_for instead of removed url_for_current

### DIFF
--- a/refried/extensions/avail_ext/templates/AvailExt.html
+++ b/refried/extensions/avail_ext/templates/AvailExt.html
@@ -60,9 +60,9 @@
 {% set vrows = extension.midvrows %}
 <h2>Budget: {{ extension._date_range() }}</h2>
 <h3>
-  <a href="{{ url_for_current(period=extension._prev_month()) }}">&lt;&lt;</a> |
-  <a href="{{ url_for_current(period=extension._period_for(today())) }}">Current period</a> |
-  <a href="{{ url_for_current(period=extension._next_month()) }}">&gt;&gt;</a>
+  <a href="{{ url_for("extension_report", report_name="AvailExt", period=extension._prev_month()) }}">&lt;&lt;</a> |
+  <a href="{{ url_for("extension_report", report_name="AvailExt", period=extension._period_for(today())) }}">Current period</a> |
+  <a href="{{ url_for("extension_report", report_name="AvailExt", period=extension._next_month()) }}">&gt;&gt;</a>
 </h3>
     <ol is="tree-table" class="flex-table tree-table">
         <li class="head">

--- a/refried/extensions/journal_ext/templates/JournalExt.html
+++ b/refried/extensions/journal_ext/templates/JournalExt.html
@@ -112,7 +112,7 @@
   <script type="text/javascript">
     function toggle_date(entry_hash) {
       let xhr = new XMLHttpRequest();
-      xhr.open('GET', "{{ url_for_current() }}?account_name={{account_name}}&toggle_date_entry_hash=" + entry_hash);
+      xhr.open('GET', "{{ url_for('extension_report', report_name='JournalExt') }}?account_name={{account_name}}&toggle_date_entry_hash=" + entry_hash);
       xhr.send();
       xhr.onload = function() {
         document.getElementById('reload-page').click();
@@ -121,7 +121,7 @@
   </script>
 
 {% macro account_link(name) %}<a class="account-link" href="{{ url_for('account', name=name) }}">{{ name }}</a>{% endmacro %}
-{% macro journal_url(aname, entry) %}{{ url_for_current(account_name=aname) }}#{{ extension._hash_entry(entry) }}{% endmacro %}
+{% macro journal_url(aname, entry) %}{{ url_for('extension_report', report_name='JournalExt', account_name=aname) }}#{{ extension._hash_entry(entry) }}{% endmacro %}
 {% macro render_metadata(metadata, entry_hash=None) -%}
 {% if metadata %}
 <dl class="metadata">


### PR DESCRIPTION
`url_for_current` was removed in fava after 1.19 (see https://github.com/beancount/fava/commit/9e990016ca444d1369bfcd7ff521035a94845c8e#diff-34e70ccbc25aaa9a79d126c4b4b93bc93948cb6dfe9bd5b5978d8a1ea4227205L187 ) and `url_for` is backwards-compatible.