### PR TITLE
Balance check respects tolerances

### DIFF
--- a/refried/plugins/rebudget.py
+++ b/refried/plugins/rebudget.py
@@ -1,6 +1,6 @@
 import collections
 from refried import is_account_account
-from beancount.core import convert
+from beancount.core import convert, interpolate
 from beancount.core.data import Open, Transaction, filter_txns
 from beancount.core.inventory import Inventory
 
@@ -38,9 +38,8 @@ def balance_check(entries, options_map):
                 asum.add_position(posting)
             elif components[0] in ('Income', 'Expenses'):
                 bsum.add_position(posting)
-    asum = asum.reduce(convert.get_weight)
-    bsum = bsum.reduce(convert.get_weight)
-    if asum != -bsum:
+    csum = asum.reduce(convert.get_weight) + bsum.reduce(convert.get_weight)
+    if not csum.is_small(interpolate.infer_tolerances({}, options_map)):
         errors.append(
             BudgetBalanceError(
                 {'filename': '<budget_balance_check>',


### PR DESCRIPTION
I was monthly-budgeting for annual expenses with `(-14.99 / 12) USD` etc. and ended up with this humorous floating point math error: `On-budget accounts and budget total do not match: (54321.71 USD) vs (54321.71000000000000000000002 USD)`. I had tolerances configured to accept this difference, but the rebudged plugin didn't take tolerances into account.

This change makes balance_check only raise the error when the difference exceeds the tolerances.

By default the tolerances are still zero, so this code will still raise the error until the user changes the default tolerances option via `option "inferred_tolerance_default" "USD:0.001"` or `option "inferred_tolerance_default" "*:0.001"`