### PR TITLE
Solve deprecation of FavaLedger.entries

### DIFF
--- a/refried/extensions/avail_ext/__init__.py
+++ b/refried/extensions/avail_ext/__init__.py
@@ -62,7 +62,7 @@ class AvailExt(FavaExtensionBase):  # pragma: no cover
         self.midsrows = ddict(Inventory)
         self.vrows = ddict(Inventory)
         self.midvrows = ddict(Inventory)
-        for entry, posting in filter_postings(self.ledger.entries):
+        for entry, posting in filter_postings(self.ledger.all_entries):
             if entry.date >= self.period_end:
                 continue
             self.vrows[posting.account].add_position(posting)


### PR DESCRIPTION
`FavaLedger.entries` has been removed in v1.23 (see [beacount/fava@bcf9fb11#diff-ca0a6675](https://github.com/beancount/fava/commit/bcf9fb115b300e510e2f09a17166bd29002a7780?diff=unified#diff-ca0a675b621fcc9e5b02737738cfd1f0e305edcb20b39edacea5b2553bdfb388)).

It causes to throw an error when trying to open the report "Budget" from [`refried/extensions/avail_ext`](https://github.com/scauligi/refried/tree/master/refried/extensions/avail_ext).

`FavaLedger.all_entries` is usable in this context, as `FavaLedger.entries` was just a wrapper over it.