### PR TITLE
Drop account name asumptions in rebudget and avail_ext

### DIFF
--- a/refried/__init__.py
+++ b/refried/__init__.py
@@ -7,7 +7,9 @@ from collections import defaultdict as ddict, OrderedDict
 from pathlib import Path
 from beancount import loader
 from beancount.core import account as acctops
+from beancount.core.account_types import get_account_type
 from beancount.core.data import Open, Close, Custom, Transaction
+from beancount.parser.options import get_account_types
 
 __version__ = '0.7.0'
 
@@ -17,8 +19,10 @@ def halfcents(d):
         s = s[:-1]
     return s
 
-def is_account_account(account):
-    return account.startswith('Assets:') or account.startswith('Liabilities:')
+def is_account_account(account, options_map):
+    account_types = get_account_types(options_map)
+    account_type = get_account_type(account)
+    return account_type in (account_types.assets, account_types.liabilities)
 
 @contextlib.contextmanager
 def _add_files(addl_files):

--- a/refried/extensions/avail_ext/__init__.py
+++ b/refried/extensions/avail_ext/__init__.py
@@ -11,6 +11,7 @@ from beancount.core.inventory import Inventory, Position, Amount
 from beancount.core.realization import RealAccount
 from beancount.core import getters
 from beancount.core import convert
+from beancount.parser.options import get_account_types
 from beancount.query import query
 
 from fava.core.tree import Tree
@@ -31,9 +32,10 @@ class AvailExt(FavaExtensionBase):  # pragma: no cover
 
     def make_table(self, period):
         """An account tree based on matching regex patterns."""
+        account_types = get_account_types(self.ledger.options)
         root = [
-            self.ledger.all_root_account.get('Income'),
-            self.ledger.all_root_account.get('Expenses'),
+            self.ledger.all_root_account.get(account_types.income),
+            self.ledger.all_root_account.get(account_types.expenses),
         ]
 
         today = datetime.date.today()

--- a/refried/plugins/clearing.py
+++ b/refried/plugins/clearing.py
@@ -16,7 +16,7 @@ def clearing(entries, options_map):
                 if not posting.meta:
                     posting = posting._replace(meta={})
                     entry.postings[i] = posting
-                if not is_account_account(posting.account):
+                if not is_account_account(posting.account, options_map):
                     if 'uncleared' in posting.meta:
                         del posting.meta['uncleared']
                     continue

--- a/refried/plugins/rebudget.py
+++ b/refried/plugins/rebudget.py
@@ -8,10 +8,10 @@ __plugins__ = ('rebudget', 'balance_check')
 
 BudgetBalanceError = collections.namedtuple('BudgetBalanceError', 'source message entry')
 
-def rebudget_entry(entry):
+def rebudget_entry(entry, options_map):
     if isinstance(entry, Transaction):
         for posting in entry.postings:
-            if is_account_account(posting.account):
+            if is_account_account(posting.account, options_map):
                 break
         else:
             if 'tx' not in entry.tags:
@@ -19,7 +19,7 @@ def rebudget_entry(entry):
     return entry
 
 def rebudget(entries, options_map):
-    return [rebudget_entry(e) for e in entries], []
+    return [rebudget_entry(e, options_map) for e in entries], []
 
 def balance_check(entries, options_map):
     errors = []

--- a/tests/test_rebudget.py
+++ b/tests/test_rebudget.py
@@ -150,3 +150,62 @@ class TestRebudget(cmptest.TestCase):
                 Expenses:Money-for-IRA   20 USD
         """
         pass
+
+
+    # Tests with different root account names
+
+    @loader.load_doc(expect_errors=False)
+    def test_leave_alone_with_other_roots(self, entries, errors, options):
+        """
+            plugin "refried.plugins.rebudget"
+
+            option "name_assets" "Activos"
+            option "name_liabilities" "Pasivos"
+            option "name_equity" "Capital"
+            option "name_income" "Ingresos"
+            option "name_expenses" "Gastos"
+
+            2020-05-28 open Activos:Corriente
+            2020-05-28 open Pasivos:Credito
+
+            2020-05-28 *
+                Activos:Corriente      -20 USD
+                Pasivos:Credito         20 USD
+        """
+        self.assertEqualEntries(self.test_leave_alone_with_other_roots.__input__, entries)
+
+    @loader.load_doc(expect_errors=False)
+    def test_expense_expense_with_other_roots(self, entries, errors, options):
+        """
+            plugin "refried.plugins.rebudget"
+
+            option "name_assets" "Activos"
+            option "name_liabilities" "Pasivos"
+            option "name_equity" "Capital"
+            option "name_income" "Ingresos"
+            option "name_expenses" "Gastos"
+
+            2020-05-28 open Gastos:Dining-Out
+            2020-05-28 open Gastos:Groceries
+
+            2020-05-28 *
+                Gastos:Dining-Out   -20 USD
+                Gastos:Groceries     20 USD
+        """
+        self.assertEqualEntries("""
+            plugin "refried.plugins.rebudget"
+
+            option "name_assets" "Activos"
+            option "name_liabilities" "Pasivos"
+            option "name_equity" "Capital"
+            option "name_income" "Ingresos"
+            option "name_expenses" "Gastos"
+
+            2020-05-28 open Gastos:Dining-Out
+            2020-05-28 open Gastos:Groceries
+
+            2020-05-28 * #rebudget
+                Gastos:Dining-Out   -20 USD
+                Gastos:Groceries     20 USD
+        """, entries)
+


### PR DESCRIPTION
I dropped the asumptions of account names in the plugin [rebudget](https://github.com/scauligi/refried/blob/master/refried/plugins/rebudget.py) and the extension [avail_ext](https://github.com/scauligi/refried/tree/master/refried/extensions/avail_ext). They now accept any root name.

As the `refried.is_account_account()` function needed to be modified, I also modified the plugin [clearing](https://github.com/scauligi/refried/blob/master/refried/plugins/clearing.py) in order not to break it. Although I didn't modify the clearing extensions ([accts_ext](https://github.com/scauligi/refried/tree/master/refried/extensions/accts_ext) & [journal_ext](https://github.com/scauligi/refried/tree/master/refried/extensions/journal_ext)). I do not know yet how to adapt the queries.